### PR TITLE
Hotfix/ring race condition

### DIFF
--- a/src/caduceus/caduceus.go
+++ b/src/caduceus/caduceus.go
@@ -46,11 +46,11 @@ func caduceus(arguments []string) int {
 		QueueSize:  caduceusConfig.JobQueueSize,
 	}.New()
 
-	serverProfiler := ServerProfilerFactory{
-		Frequency: caduceusConfig.ProfilerFrequency,
-		Duration:  caduceusConfig.ProfilerDuration,
-		QueueSize: caduceusConfig.ProfilerQueueSize,
-	}.New()
+	// serverProfiler := ServerProfilerFactory{
+	// 	Frequency: caduceusConfig.ProfilerFrequency,
+	// 	Duration:  caduceusConfig.ProfilerDuration,
+	// 	QueueSize: caduceusConfig.ProfilerQueueSize,
+	// }.New()
 
 	serverWrapper := &ServerHandler{
 		Logger: logger,
@@ -61,8 +61,7 @@ func caduceus(arguments []string) int {
 	}
 
 	profileWrapper := &ProfileHandler{
-		Logger:           logger,
-		caduceusProfiler: serverProfiler,
+		Logger: logger,
 	}
 
 	validator := secure.Validators{

--- a/src/caduceus/caduceus.go
+++ b/src/caduceus/caduceus.go
@@ -46,11 +46,12 @@ func caduceus(arguments []string) int {
 		QueueSize:  caduceusConfig.JobQueueSize,
 	}.New()
 
-	// serverProfiler := ServerProfilerFactory{
+	// TODO: use the below to fill out the parts of what will eventually handle outboundSenders
+	// serverProfilerFactory := ServerProfilerFactory{
 	// 	Frequency: caduceusConfig.ProfilerFrequency,
 	// 	Duration:  caduceusConfig.ProfilerDuration,
 	// 	QueueSize: caduceusConfig.ProfilerQueueSize,
-	// }.New()
+	// }
 
 	serverWrapper := &ServerHandler{
 		Logger: logger,

--- a/src/caduceus/caduceus.go
+++ b/src/caduceus/caduceus.go
@@ -55,8 +55,7 @@ func caduceus(arguments []string) int {
 	serverWrapper := &ServerHandler{
 		Logger: logger,
 		caduceusHandler: &CaduceusHandler{
-			Logger:           logger,
-			caduceusProfiler: serverProfiler,
+			Logger: logger,
 		},
 		doJob: workerPool.Send,
 	}

--- a/src/caduceus/caduceusProfiler.go
+++ b/src/caduceus/caduceusProfiler.go
@@ -20,7 +20,7 @@ func (spf ServerProfilerFactory) New() (serverProfiler ServerProfiler) {
 		profilerRing: NewCaduceusRing(spf.Duration),
 		inChan:       make(chan interface{}, spf.QueueSize),
 		quit:         make(chan struct{}),
-		rwMutex:      &sync.RWMutex{},
+		rwMutex:      new(sync.RWMutex),
 	}
 
 	go newCaduceusProfiler.aggregate(newCaduceusProfiler.quit)

--- a/src/caduceus/caduceusProfiler.go
+++ b/src/caduceus/caduceusProfiler.go
@@ -14,7 +14,12 @@ type ServerProfilerFactory struct {
 
 // New will be used to initialize a new server profiler for caduceus and get
 // the gears in motion for aggregating data
-func (spf ServerProfilerFactory) New() (serverProfiler ServerProfiler) {
+func (spf ServerProfilerFactory) New() (serverProfiler ServerProfiler, err error) {
+	if spf.Frequency < 1 || spf.Duration < 1 || spf.QueueSize < 1 {
+		err = errors.New("No parameter to the ServerProfilerFactory can be less than 1.")
+		return
+	}
+
 	newCaduceusProfiler := &caduceusProfiler{
 		frequency:    spf.Frequency,
 		profilerRing: NewCaduceusRing(spf.Duration),

--- a/src/caduceus/caduceusProfiler_test.go
+++ b/src/caduceus/caduceusProfiler_test.go
@@ -41,8 +41,17 @@ func TestCaduceusProfilerFactory(t *testing.T) {
 
 	t.Run("TestCaduceusProfilerFactoryNew", func(t *testing.T) {
 		require.NotNil(t, testFactory)
-		testProfiler := testFactory.New()
+		testProfiler, err := testFactory.New()
 		assert.NotNil(testProfiler)
+		assert.Nil(err)
+	})
+
+	t.Run("TestCaduceusProfilerFactoryNewInvalidParameters", func(t *testing.T) {
+		require.NotNil(t, testFactory)
+		testFactory.Frequency = 0
+		testProfiler, err := testFactory.New()
+		assert.Nil(testProfiler)
+		assert.NotNil(err)
 	})
 }
 

--- a/src/caduceus/caduceusRing.go
+++ b/src/caduceus/caduceusRing.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"container/ring"
+	"sync"
 )
 
 // NewCaduceusRing is used to instantiate a new ring for profiling outbound messages
 func NewCaduceusRing(inSize int) (myServerRing ServerRing) {
 	myServerRing = &caduceusRing{
-		Ring: ring.New(inSize),
+		Ring:    ring.New(inSize),
+		rwMutex: new(sync.RWMutex),
 	}
 
 	return
@@ -22,21 +24,26 @@ type ServerRing interface {
 // underlying implementation of the ring
 type caduceusRing struct {
 	*ring.Ring
+	rwMutex *sync.RWMutex
 }
 
 // Add adds a value to the server ring, which will overwrite the oldest value if full
 func (sr *caduceusRing) Add(inValue interface{}) {
+	sr.rwMutex.Lock()
 	sr.Value = inValue
 	sr.Ring = sr.Next()
+	sr.rwMutex.Unlock()
 }
 
 // Snapshot is used to grab the ring and store it as an array so we can profile some things
 func (sr *caduceusRing) Snapshot() (values []interface{}) {
+	sr.rwMutex.RLock()
 	sr.Do(func(x interface{}) {
 		if x != nil {
 			values = append(values, x)
 		}
 	})
+	sr.rwMutex.RUnlock()
 
 	return
 }

--- a/src/caduceus/caduceus_type.go
+++ b/src/caduceus/caduceus_type.go
@@ -50,7 +50,6 @@ type RequestHandler interface {
 
 type CaduceusHandler struct {
 	logging.Logger
-	caduceusProfiler ServerProfiler
 }
 
 func (ch *CaduceusHandler) HandleRequest(workerID int, inRequest CaduceusRequest) {
@@ -61,9 +60,6 @@ func (ch *CaduceusHandler) HandleRequest(workerID int, inRequest CaduceusRequest
 	ch.Info("Worker #%d received a request, url:\t\t%s", workerID, inRequest.TargetURL)
 
 	inRequest.Timestamps.TimeProcessingEnd = time.Now()
-
-	// TODO: temporarily adding the whole request to a profiler for testing purposes
-	ch.caduceusProfiler.Send(inRequest)
 
 	ch.Info("Worker #%d printing message time stats:\t%v", workerID, inRequest.Timestamps)
 }

--- a/src/caduceus/http.go
+++ b/src/caduceus/http.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"github.com/Comcast/webpa-common/logging"
 	"io/ioutil"
 	"net/http"
@@ -85,7 +84,6 @@ func (sh *ServerHandler) ServeHTTP(response http.ResponseWriter, request *http.R
 
 type ProfileHandler struct {
 	logging.Logger
-	caduceusProfiler ServerProfiler
 }
 
 // TODO: temporarily adding this to check and see if we're getting what we expect
@@ -93,15 +91,7 @@ func (ph *ProfileHandler) ServeHTTP(response http.ResponseWriter, request *http.
 	defer request.Body.Close()
 
 	ph.Info("Receiving request for server stats...")
-	stats := ph.caduceusProfiler.Report()
-	b, err := json.Marshal(stats)
 
-	if err != nil {
-		response.WriteHeader(http.StatusInternalServerError)
-		response.Write([]byte("Error marshalling the data into a JSON object."))
-	} else {
-		response.WriteHeader(http.StatusOK)
-		response.Write(b)
-		response.Write([]byte("\n"))
-	}
+	response.WriteHeader(http.StatusOK)
+	response.Write([]byte("Placeholder.\n"))
 }

--- a/src/caduceus/outboundSender.go
+++ b/src/caduceus/outboundSender.go
@@ -347,10 +347,10 @@ func (obs *OutboundSender) worker(id int) {
 				} else {
 					if (200 <= resp.StatusCode) && (resp.StatusCode <= 204) {
 						// Report success
-						// obs.profiler.Add(work.req) <-- Race condition!
+						obs.profiler.Add(work.req)
 					} else {
 						// Report partial success
-						// obs.profiler.Add(work.req) <-- Race condition!
+						obs.profiler.Add(work.req)
 					}
 				}
 			}

--- a/src/caduceus/outboundSender.go
+++ b/src/caduceus/outboundSender.go
@@ -85,9 +85,9 @@ type OutboundSenderFactory struct {
 	// Must be greater then 0 seconds
 	CutOffPeriod time.Duration
 
-	// The server profiler that we want to be calling whenever
-	// we service a request.
-	Profiler ServerProfiler
+	// The factory that we'll use to make new ServerProfilers on a per
+	// outboundSender basis
+	ProfilerFactory ServerProfilerFactory
 
 	// The logger to use.
 	Logger logging.Logger
@@ -166,13 +166,11 @@ func (osf OutboundSenderFactory) New() (obs *OutboundSender, err error) {
 		}
 	}
 
-	if osf.Profiler == nil {
+	obs.profiler, err = osf.ProfilerFactory.New()
+	if err != nil {
 		obs = nil
-		err = errors.New("A ServerProfiler must be provided for an outboundSender to start.")
 		return
 	}
-
-	obs.profiler = osf.Profiler
 
 	// Give us some head room so that we don't block when we get near the
 	// completely full point.

--- a/src/caduceus/outboundSender.go
+++ b/src/caduceus/outboundSender.go
@@ -166,6 +166,12 @@ func (osf OutboundSenderFactory) New() (obs *OutboundSender, err error) {
 		}
 	}
 
+	if osf.Profiler == nil {
+		obs = nil
+		err = errors.New("A ServerProfiler must be provided for an outboundSender to start.")
+		return
+	}
+
 	// Give us some head room so that we don't block when we get near the
 	// completely full point.
 	obs.queue = make(chan outboundRequest, osf.QueueSize+10)

--- a/src/caduceus/outboundSender.go
+++ b/src/caduceus/outboundSender.go
@@ -172,6 +172,8 @@ func (osf OutboundSenderFactory) New() (obs *OutboundSender, err error) {
 		return
 	}
 
+	obs.profiler = osf.Profiler
+
 	// Give us some head room so that we don't block when we get near the
 	// completely full point.
 	obs.queue = make(chan outboundRequest, osf.QueueSize+10)
@@ -219,8 +221,6 @@ func (osf OutboundSenderFactory) New() (obs *OutboundSender, err error) {
 			obs.matcher[key] = list
 		}
 	}
-
-	obs.profiler = osf.Profiler
 
 	obs.wg.Add(osf.NumWorkers)
 	for i := 0; i < osf.NumWorkers; i++ {

--- a/src/caduceus/outboundSender_test.go
+++ b/src/caduceus/outboundSender_test.go
@@ -12,6 +12,14 @@ import (
 	"time"
 )
 
+var (
+	testServerProfiler = ServerProfilerFactory{
+		Frequency: 10,
+		Duration:  6,
+		QueueSize: 100,
+	}.New()
+)
+
 // Make a simple RoundTrip implementation that let's me short-circuit the network
 type transport struct {
 	i  int32
@@ -50,6 +58,7 @@ func simpleSetup(trans *transport, cutOffPeriod time.Duration, matcher map[strin
 		CutOffPeriod: cutOffPeriod,
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 		Logger:       getLogger(),
 	}.New()
 	return
@@ -174,6 +183,7 @@ func TestInvalidEventRegex(t *testing.T) {
 		Events:      []string{"[[:123"},
 		NumWorkers:  10,
 		QueueSize:   10,
+		Profiler:    testServerProfiler,
 		Logger:      getLogger(),
 	}.New()
 	assert.Nil(obs)
@@ -194,6 +204,7 @@ func TestInvalidUrl(t *testing.T) {
 		Events:      []string{"iot"},
 		NumWorkers:  10,
 		QueueSize:   10,
+		Profiler:    testServerProfiler,
 		Logger:      getLogger(),
 	}.New()
 	assert.Nil(obs)
@@ -206,6 +217,7 @@ func TestInvalidUrl(t *testing.T) {
 		Events:      []string{"iot"},
 		NumWorkers:  10,
 		QueueSize:   10,
+		Profiler:    testServerProfiler,
 		Logger:      getLogger(),
 	}.New()
 	assert.Nil(obs)
@@ -224,6 +236,7 @@ func TestInvalidClient(t *testing.T) {
 		CutOffPeriod: time.Second,
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 		Logger:       getLogger(),
 	}.New()
 	assert.Nil(obs)
@@ -242,6 +255,7 @@ func TestInvalidLogger(t *testing.T) {
 		CutOffPeriod: time.Second,
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
@@ -261,6 +275,7 @@ func TestFailureURL(t *testing.T) {
 		QueueSize:    10,
 		Logger:       getLogger(),
 		FailureURL:   "invalid",
+		Profiler:     testServerProfiler,
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
@@ -277,6 +292,7 @@ func TestInvalidEvents(t *testing.T) {
 		CutOffPeriod: time.Second,
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 		Logger:       getLogger(),
 	}.New()
 	assert.Nil(obs)
@@ -291,6 +307,7 @@ func TestInvalidEvents(t *testing.T) {
 		Events:       []string{"iot(.*"},
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 		Logger:       getLogger(),
 	}.New()
 	assert.Nil(obs)
@@ -311,6 +328,7 @@ func TestExtend(t *testing.T) {
 		CutOffPeriod: time.Second,
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 		Logger:       getLogger(),
 	}.New()
 	assert.Nil(err)
@@ -342,6 +360,7 @@ func TestOverflowNoFailureURL(t *testing.T) {
 		CutOffPeriod: time.Second,
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 		Logger:       logger,
 	}.New()
 	assert.Nil(err)
@@ -381,6 +400,7 @@ func TestOverflowValidFailureURL(t *testing.T) {
 		CutOffPeriod: time.Second,
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 		Logger:       logger,
 		FailureURL:   "http://localhost:12345/bar",
 	}.New()
@@ -422,6 +442,7 @@ func TestOverflowValidFailureURLWithSecret(t *testing.T) {
 		CutOffPeriod: time.Second,
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 		Logger:       logger,
 		FailureURL:   "http://localhost:12345/bar",
 	}.New()
@@ -455,6 +476,7 @@ func TestOverflowValidFailureURLError(t *testing.T) {
 		CutOffPeriod: time.Second,
 		NumWorkers:   10,
 		QueueSize:    10,
+		Profiler:     testServerProfiler,
 		Logger:       logger,
 		FailureURL:   "http://localhost:12345/bar",
 	}.New()
@@ -500,6 +522,7 @@ func TestOverflow(t *testing.T) {
 		CutOffPeriod: 4 * time.Second,
 		NumWorkers:   1,
 		QueueSize:    2,
+		Profiler:     testServerProfiler,
 		Logger:       logger,
 		FailureURL:   "http://localhost:12345/bar",
 	}.New()

--- a/src/caduceus/outboundSender_test.go
+++ b/src/caduceus/outboundSender_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	testServerProfiler = ServerProfilerFactory{
+	testServerProfiler, _ = ServerProfilerFactory{
 		Frequency: 10,
 		Duration:  6,
 		QueueSize: 100,

--- a/src/caduceus/outboundSender_test.go
+++ b/src/caduceus/outboundSender_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 var (
-	testServerProfiler, _ = ServerProfilerFactory{
+	testServerProfilerFactory = ServerProfilerFactory{
 		Frequency: 10,
 		Duration:  6,
 		QueueSize: 100,
-	}.New()
+	}
 )
 
 // Make a simple RoundTrip implementation that let's me short-circuit the network
@@ -48,18 +48,18 @@ func simpleSetup(trans *transport, cutOffPeriod time.Duration, matcher map[strin
 	}
 
 	obs, err = OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		ContentType:  "application/json",
-		Client:       &http.Client{Transport: trans},
-		Secret:       "123456",
-		Until:        time.Now().Add(60 * time.Second),
-		Events:       []string{"iot", "test"},
-		Matchers:     matcher,
-		CutOffPeriod: cutOffPeriod,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
-		Logger:       getLogger(),
+		URL:             "http://localhost:9999/foo",
+		ContentType:     "application/json",
+		Client:          &http.Client{Transport: trans},
+		Secret:          "123456",
+		Until:           time.Now().Add(60 * time.Second),
+		Events:          []string{"iot", "test"},
+		Matchers:        matcher,
+		CutOffPeriod:    cutOffPeriod,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          getLogger(),
 	}.New()
 	return
 }
@@ -176,15 +176,15 @@ func TestInvalidEventRegex(t *testing.T) {
 	assert := assert.New(t)
 
 	obs, err := OutboundSenderFactory{
-		URL:         "http://localhost:9999/foo",
-		ContentType: "application/json",
-		Client:      &http.Client{},
-		Until:       time.Now().Add(60 * time.Second),
-		Events:      []string{"[[:123"},
-		NumWorkers:  10,
-		QueueSize:   10,
-		Profiler:    testServerProfiler,
-		Logger:      getLogger(),
+		URL:             "http://localhost:9999/foo",
+		ContentType:     "application/json",
+		Client:          &http.Client{},
+		Until:           time.Now().Add(60 * time.Second),
+		Events:          []string{"[[:123"},
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          getLogger(),
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
@@ -197,28 +197,28 @@ func TestInvalidUrl(t *testing.T) {
 	assert := assert.New(t)
 
 	obs, err := OutboundSenderFactory{
-		URL:         "invalid",
-		ContentType: "application/json",
-		Client:      &http.Client{},
-		Until:       time.Now().Add(60 * time.Second),
-		Events:      []string{"iot"},
-		NumWorkers:  10,
-		QueueSize:   10,
-		Profiler:    testServerProfiler,
-		Logger:      getLogger(),
+		URL:             "invalid",
+		ContentType:     "application/json",
+		Client:          &http.Client{},
+		Until:           time.Now().Add(60 * time.Second),
+		Events:          []string{"iot"},
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          getLogger(),
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
 
 	obs, err = OutboundSenderFactory{
-		ContentType: "application/json",
-		Client:      &http.Client{},
-		Until:       time.Now().Add(60 * time.Second),
-		Events:      []string{"iot"},
-		NumWorkers:  10,
-		QueueSize:   10,
-		Profiler:    testServerProfiler,
-		Logger:      getLogger(),
+		ContentType:     "application/json",
+		Client:          &http.Client{},
+		Until:           time.Now().Add(60 * time.Second),
+		Events:          []string{"iot"},
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          getLogger(),
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
@@ -229,15 +229,15 @@ func TestInvalidUrl(t *testing.T) {
 func TestInvalidClient(t *testing.T) {
 	assert := assert.New(t)
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		ContentType:  "application/json",
-		Until:        time.Now().Add(60 * time.Second),
-		Events:       []string{"iot"},
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
-		Logger:       getLogger(),
+		URL:             "http://localhost:9999/foo",
+		ContentType:     "application/json",
+		Until:           time.Now().Add(60 * time.Second),
+		Events:          []string{"iot"},
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          getLogger(),
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
@@ -247,15 +247,15 @@ func TestInvalidClient(t *testing.T) {
 func TestInvalidLogger(t *testing.T) {
 	assert := assert.New(t)
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		Client:       &http.Client{},
-		ContentType:  "application/json",
-		Until:        time.Now().Add(60 * time.Second),
-		Events:       []string{"iot"},
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
+		URL:             "http://localhost:9999/foo",
+		Client:          &http.Client{},
+		ContentType:     "application/json",
+		Until:           time.Now().Add(60 * time.Second),
+		Events:          []string{"iot"},
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
@@ -265,17 +265,17 @@ func TestInvalidLogger(t *testing.T) {
 func TestFailureURL(t *testing.T) {
 	assert := assert.New(t)
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		Client:       &http.Client{},
-		ContentType:  "application/json",
-		Until:        time.Now().Add(60 * time.Second),
-		Events:       []string{"iot"},
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Logger:       getLogger(),
-		FailureURL:   "invalid",
-		Profiler:     testServerProfiler,
+		URL:             "http://localhost:9999/foo",
+		Client:          &http.Client{},
+		ContentType:     "application/json",
+		Until:           time.Now().Add(60 * time.Second),
+		Events:          []string{"iot"},
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		Logger:          getLogger(),
+		FailureURL:      "invalid",
+		ProfilerFactory: testServerProfilerFactory,
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
@@ -285,48 +285,49 @@ func TestFailureURL(t *testing.T) {
 func TestInvalidEvents(t *testing.T) {
 	assert := assert.New(t)
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		Client:       &http.Client{},
-		ContentType:  "application/json",
-		Until:        time.Now().Add(60 * time.Second),
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
-		Logger:       getLogger(),
+		URL:             "http://localhost:9999/foo",
+		Client:          &http.Client{},
+		ContentType:     "application/json",
+		Until:           time.Now().Add(60 * time.Second),
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          getLogger(),
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
 
 	obs, err = OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		Client:       &http.Client{},
-		ContentType:  "application/json",
-		Until:        time.Now().Add(60 * time.Second),
-		CutOffPeriod: time.Second,
-		Events:       []string{"iot(.*"},
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
-		Logger:       getLogger(),
+		URL:             "http://localhost:9999/foo",
+		Client:          &http.Client{},
+		ContentType:     "application/json",
+		Until:           time.Now().Add(60 * time.Second),
+		CutOffPeriod:    time.Second,
+		Events:          []string{"iot(.*"},
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          getLogger(),
 	}.New()
 	assert.Nil(obs)
 	assert.NotNil(err)
 }
 
 // Simple test that checks for no profiler
-func TestInvalidProfiler(t *testing.T) {
+func TestInvalidProfilerFactory(t *testing.T) {
 	assert := assert.New(t)
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		Client:       &http.Client{},
-		ContentType:  "application/json",
-		Until:        time.Now(),
-		Events:       []string{"iot", "test"},
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Logger:       getLogger(),
+		URL:             "http://localhost:9999/foo",
+		Client:          &http.Client{},
+		ContentType:     "application/json",
+		Until:           time.Now(),
+		Events:          []string{"iot", "test"},
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: ServerProfilerFactory{},
+		Logger:          getLogger(),
 	}.New()
 
 	assert.Nil(obs)
@@ -339,16 +340,16 @@ func TestExtend(t *testing.T) {
 
 	now := time.Now()
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		ContentType:  "application/json",
-		Client:       &http.Client{},
-		Until:        now,
-		Events:       []string{"iot", "test"},
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
-		Logger:       getLogger(),
+		URL:             "http://localhost:9999/foo",
+		ContentType:     "application/json",
+		Client:          &http.Client{},
+		Until:           now,
+		Events:          []string{"iot", "test"},
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          getLogger(),
 	}.New()
 	assert.Nil(err)
 
@@ -371,16 +372,16 @@ func TestOverflowNoFailureURL(t *testing.T) {
 	logger, _ := loggerFactory.NewLogger("test")
 
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		ContentType:  "application/json",
-		Client:       &http.Client{},
-		Until:        time.Now(),
-		Events:       []string{"iot", "test"},
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
-		Logger:       logger,
+		URL:             "http://localhost:9999/foo",
+		ContentType:     "application/json",
+		Client:          &http.Client{},
+		Until:           time.Now(),
+		Events:          []string{"iot", "test"},
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          logger,
 	}.New()
 	assert.Nil(err)
 
@@ -411,17 +412,17 @@ func TestOverflowValidFailureURL(t *testing.T) {
 	}
 
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		ContentType:  "application/json",
-		Client:       &http.Client{Transport: trans},
-		Until:        time.Now(),
-		Events:       []string{"iot", "test"},
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
-		Logger:       logger,
-		FailureURL:   "http://localhost:12345/bar",
+		URL:             "http://localhost:9999/foo",
+		ContentType:     "application/json",
+		Client:          &http.Client{Transport: trans},
+		Until:           time.Now(),
+		Events:          []string{"iot", "test"},
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          logger,
+		FailureURL:      "http://localhost:12345/bar",
 	}.New()
 	assert.Nil(err)
 
@@ -452,18 +453,18 @@ func TestOverflowValidFailureURLWithSecret(t *testing.T) {
 	}
 
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		ContentType:  "application/json",
-		Client:       &http.Client{Transport: trans},
-		Until:        time.Now(),
-		Secret:       "123456",
-		Events:       []string{"iot", "test"},
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
-		Logger:       logger,
-		FailureURL:   "http://localhost:12345/bar",
+		URL:             "http://localhost:9999/foo",
+		ContentType:     "application/json",
+		Client:          &http.Client{Transport: trans},
+		Until:           time.Now(),
+		Secret:          "123456",
+		Events:          []string{"iot", "test"},
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          logger,
+		FailureURL:      "http://localhost:12345/bar",
 	}.New()
 	assert.Nil(err)
 
@@ -487,17 +488,17 @@ func TestOverflowValidFailureURLError(t *testing.T) {
 	}
 
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		ContentType:  "application/json",
-		Client:       &http.Client{Transport: trans},
-		Until:        time.Now(),
-		Events:       []string{"iot", "test"},
-		CutOffPeriod: time.Second,
-		NumWorkers:   10,
-		QueueSize:    10,
-		Profiler:     testServerProfiler,
-		Logger:       logger,
-		FailureURL:   "http://localhost:12345/bar",
+		URL:             "http://localhost:9999/foo",
+		ContentType:     "application/json",
+		Client:          &http.Client{Transport: trans},
+		Until:           time.Now(),
+		Events:          []string{"iot", "test"},
+		CutOffPeriod:    time.Second,
+		NumWorkers:      10,
+		QueueSize:       10,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          logger,
+		FailureURL:      "http://localhost:12345/bar",
 	}.New()
 	assert.Nil(err)
 
@@ -533,17 +534,17 @@ func TestOverflow(t *testing.T) {
 	}
 
 	obs, err := OutboundSenderFactory{
-		URL:          "http://localhost:9999/foo",
-		ContentType:  "application/json",
-		Client:       &http.Client{Transport: trans},
-		Until:        time.Now().Add(30 * time.Second),
-		Events:       []string{"iot", "test"},
-		CutOffPeriod: 4 * time.Second,
-		NumWorkers:   1,
-		QueueSize:    2,
-		Profiler:     testServerProfiler,
-		Logger:       logger,
-		FailureURL:   "http://localhost:12345/bar",
+		URL:             "http://localhost:9999/foo",
+		ContentType:     "application/json",
+		Client:          &http.Client{Transport: trans},
+		Until:           time.Now().Add(30 * time.Second),
+		Events:          []string{"iot", "test"},
+		CutOffPeriod:    4 * time.Second,
+		NumWorkers:      1,
+		QueueSize:       2,
+		ProfilerFactory: testServerProfilerFactory,
+		Logger:          logger,
+		FailureURL:      "http://localhost:12345/bar",
 	}.New()
 	assert.Nil(err)
 

--- a/src/caduceus/outboundSender_test.go
+++ b/src/caduceus/outboundSender_test.go
@@ -314,6 +314,25 @@ func TestInvalidEvents(t *testing.T) {
 	assert.NotNil(err)
 }
 
+// Simple test that checks for no profiler
+func TestInvalidProfiler(t *testing.T) {
+	assert := assert.New(t)
+	obs, err := OutboundSenderFactory{
+		URL:          "http://localhost:9999/foo",
+		Client:       &http.Client{},
+		ContentType:  "application/json",
+		Until:        time.Now(),
+		Events:       []string{"iot", "test"},
+		CutOffPeriod: time.Second,
+		NumWorkers:   10,
+		QueueSize:    10,
+		Logger:       getLogger(),
+	}.New()
+
+	assert.Nil(obs)
+	assert.NotNil(err)
+}
+
 // Simple test that ensures that Extend() only does that
 func TestExtend(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
Made it so that we now check for error conditions in the ServerProfilerFactory when making a new ServerProfiler. Made it so that outboundSenderFactory now takes in a ServerProfilerFactory to call New on. Made it so that outoundSender now has its own unique ServerProfiler rather than just a ServerRing. Updated all unit tests accordingly.