### PR TITLE
Change the output delivery so it delivers the expected payload & not …

### DIFF
--- a/src/caduceus/caduceusProfiler.go
+++ b/src/caduceus/caduceusProfiler.go
@@ -157,7 +157,7 @@ func (cp *caduceusProfiler) process(raw []interface{}) (rv interface{}) {
 		for i, rawElement := range raw {
 			telemetryData := rawElement.(CaduceusTelemetry)
 
-			tonnage += telemetryData.PayloadSize
+			tonnage += telemetryData.RawPayloadSize
 
 			latency[i] = telemetryData.TimeSent.Sub(telemetryData.TimeReceived).Nanoseconds()
 			processingTime[i] = telemetryData.TimeOutboundAccepted.Sub(telemetryData.TimeReceived).Nanoseconds()

--- a/src/caduceus/caduceusProfiler_test.go
+++ b/src/caduceus/caduceusProfiler_test.go
@@ -58,7 +58,7 @@ func TestCaduceusProfilerFactory(t *testing.T) {
 
 func TestCaduceusProfiler(t *testing.T) {
 	assert := assert.New(t)
-	testMsg := CaduceusTelemetry{PayloadSize: 12}
+	testMsg := CaduceusTelemetry{RawPayloadSize: 12}
 	testData := make([]interface{}, 0)
 	testData = append(testData, testMsg)
 
@@ -129,7 +129,7 @@ func TestCaduceusProfiler(t *testing.T) {
 		testResults := testProfiler.Report()
 
 		assert.Equal(1, len(testResults))
-		assert.Equal(CaduceusTelemetry{PayloadSize: 12}, testResults[0].(CaduceusTelemetry))
+		assert.Equal(CaduceusTelemetry{RawPayloadSize: 12}, testResults[0].(CaduceusTelemetry))
 
 		fakeRing.AssertExpectations(t)
 	})
@@ -141,12 +141,12 @@ func TestCaduceusProfiler(t *testing.T) {
 func TestCaduceusProfilerProcess(t *testing.T) {
 	set := []CaduceusTelemetry{
 		{
-			PayloadSize:  100,
+			RawPayloadSize:  100,
 			TimeReceived: time.Unix(1000, 0),
 			TimeSent:     time.Unix(1000, 10),
 		},
 		{
-			PayloadSize:  200,
+			RawPayloadSize:  200,
 			TimeReceived: time.Unix(1010, 0),
 			TimeSent:     time.Unix(1010, 12),
 		},

--- a/src/caduceus/caduceus_type.go
+++ b/src/caduceus/caduceus_type.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Comcast/webpa-common/logging"
 	"github.com/Comcast/webpa-common/secure"
 	"github.com/Comcast/webpa-common/secure/key"
+	"github.com/Comcast/webpa-common/wrp"
 	"time"
 )
 
@@ -48,10 +49,12 @@ type JWTValidator struct {
 
 // Below is the struct we're using to create a request to caduceus
 type CaduceusRequest struct {
-	Payload     []byte
-	ContentType string
-	TargetURL   string
-	Telemetry   CaduceusTelemetry
+	RawPayload      []byte
+	PayloadAsWrp    *wrp.Message
+	OutgoingPayload []byte
+	ContentType     string
+	TargetURL       string
+	Telemetry       CaduceusTelemetry
 }
 
 const (
@@ -61,7 +64,7 @@ const (
 )
 
 type CaduceusTelemetry struct {
-	PayloadSize          int
+	RawPayloadSize       int
 	TimeReceived         time.Time
 	TimeAccepted         time.Time
 	TimeSentToOutbound   time.Time

--- a/src/caduceus/http.go
+++ b/src/caduceus/http.go
@@ -76,13 +76,13 @@ func (sh *ServerHandler) ServeHTTP(response http.ResponseWriter, request *http.R
 	targetURL := request.URL.String()
 
 	caduceusRequest := CaduceusRequest{
-		Payload:     payload,
+		RawPayload:  payload,
 		ContentType: contentType,
 		TargetURL:   targetURL,
 		Telemetry:   stats,
 	}
 
-	caduceusRequest.Telemetry.PayloadSize = len(payload)
+	caduceusRequest.Telemetry.RawPayloadSize = len(payload)
 	caduceusRequest.Telemetry.TimeAccepted = time.Now()
 
 	err = sh.doJob(func(workerID int) { sh.caduceusHandler.HandleRequest(workerID, caduceusRequest) })
@@ -96,7 +96,7 @@ func (sh *ServerHandler) ServeHTTP(response http.ResponseWriter, request *http.R
 		response.WriteHeader(http.StatusAccepted)
 		response.Write([]byte("Request placed on to queue.\n"))
 		sh.Trace("Request placed on to queue.")
-		sh.caduceusHealth.IncrementBucket(caduceusRequest.Telemetry.PayloadSize)
+		sh.caduceusHealth.IncrementBucket(caduceusRequest.Telemetry.RawPayloadSize)
 	}
 }
 

--- a/src/caduceus/senderWrapper.go
+++ b/src/caduceus/senderWrapper.go
@@ -157,12 +157,13 @@ func (sw *CaduceusSenderWrapper) Queue(req CaduceusRequest) {
 		}
 
 	case "application/msgpack":
-		decoder := wrp.NewDecoderBytes(req.Payload, wrp.Msgpack)
+		decoder := wrp.NewDecoderBytes(req.RawPayload, wrp.Msgpack)
 		message := new(wrp.Message)
 		if err := decoder.Decode(message); nil == err {
+			req.PayloadAsWrp = message
 			sw.mutex.RLock()
 			for _, v := range sw.senders {
-				v.QueueWrp(req, message.Metadata, message.Destination, message.Source, message.TransactionUUID)
+				v.QueueWrp(req)
 			}
 			sw.mutex.RUnlock()
 		}

--- a/src/caduceus/senderWrapper_test.go
+++ b/src/caduceus/senderWrapper_test.go
@@ -86,17 +86,17 @@ func TestSwSimple(t *testing.T) {
 	assert.Nil(err)
 
 	iot := CaduceusRequest{
-		Payload:     []byte("Hello, world."),
+		RawPayload:  []byte("Hello, world."),
 		ContentType: "application/json",
 		TargetURL:   "http://foo.com/api/v2/notify/mac:112233445566/event/iot",
 	}
 	test := CaduceusRequest{
-		Payload:     []byte("Hello, world."),
+		RawPayload:  []byte("Hello, world."),
 		ContentType: "application/json",
 		TargetURL:   "http://foo.com/api/v2/notify/mac:112233445566/event/test",
 	}
 	wrp := CaduceusRequest{
-		Payload:     buffer.Bytes(),
+		RawPayload:  buffer.Bytes(),
 		ContentType: "application/msgpack",
 		TargetURL:   "http://foo.com/api/v2/notify/mac:112233445566/event/wrp",
 	}


### PR DESCRIPTION
…the entire wrp message.  The contentType is now set via the wrp message value or defaults to 'application/json' for wrp based eventing.