### PR TITLE
Moved the empty request tracking into the ServerHandler

### DIFF
--- a/src/caduceus/caduceus.go
+++ b/src/caduceus/caduceus.go
@@ -181,7 +181,8 @@ func caduceus(arguments []string) int {
 			senderWrapper:   caduceusSenderWrapper,
 			Logger:          logger,
 		},
-		doJob: workerPool.Send,
+		emptyRequests: metricsRegistry.NewCounter(EmptyRequestBodyCounter),
+		doJob:         workerPool.Send,
 	}
 
 	profileWrapper := &ProfileHandler{
@@ -202,7 +203,7 @@ func caduceus(arguments []string) int {
 		Logger:              logger,
 	}
 
-	caduceusHandler := alice.New(authHandler.Decorate, TrackEmptyRequestBody(metricsRegistry))
+	caduceusHandler := alice.New(authHandler.Decorate)
 
 	router := mux.NewRouter()
 

--- a/src/caduceus/metrics.go
+++ b/src/caduceus/metrics.go
@@ -1,12 +1,7 @@
 package main
 
 import (
-	"bytes"
-	"io/ioutil"
-	"net/http"
-
 	"github.com/Comcast/webpa-common/xmetrics"
-	"github.com/go-kit/kit/metrics/provider"
 )
 
 const (
@@ -19,28 +14,5 @@ func Metrics() []xmetrics.Metric {
 			Name: EmptyRequestBodyCounter,
 			Type: "counter",
 		},
-	}
-}
-
-// TrackEmptyRequestBody increments the EmptyRequestBodyCounter anytime an empty request is received
-func TrackEmptyRequestBody(provider provider.Provider) func(http.Handler) http.Handler {
-	counter := provider.NewCounter(EmptyRequestBodyCounter)
-
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-			// don't trust the Content-Length header ...
-			body, err := ioutil.ReadAll(request.Body)
-			if err != nil {
-				response.WriteHeader(http.StatusBadRequest)
-				return
-			}
-
-			if len(body) == 0 {
-				counter.Add(1.0)
-			}
-
-			request.Body = ioutil.NopCloser(bytes.NewReader(body))
-			next.ServeHTTP(response, request)
-		})
 	}
 }


### PR DESCRIPTION
You're right ... I think this is better.  It also isn't a design problem, as the ServerHandler is already dealing with the request body's business logic.