### PR TITLE
event regular expression match is now less greedy.  the event must ma…

### DIFF
--- a/src/caduceus/outboundSender.go
+++ b/src/caduceus/outboundSender.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -225,7 +226,7 @@ func (osf OutboundSenderFactory) New() (obs OutboundSender, err error) {
 	// Create the event regex objects
 	for _, event := range osf.Listener.Events {
 		var re *regexp.Regexp
-		if re, err = regexp.Compile(event); nil != err {
+		if re, err = regexp.Compile("^" + event + "$"); nil != err {
 			return
 		}
 
@@ -364,7 +365,7 @@ func (obs *CaduceusOutboundSender) QueueWrp(req CaduceusRequest) {
 
 	if now.Before(deliverUntil) && now.After(dropUntil) {
 		for _, eventRegex := range obs.events {
-			if eventRegex.MatchString(req.PayloadAsWrp.Destination) {
+			if eventRegex.MatchString(strings.TrimPrefix(req.PayloadAsWrp.Destination, "event:")) {
 				matchDevice := (nil == obs.matcher)
 				if nil != obs.matcher {
 					for _, deviceRegex := range obs.matcher {

--- a/src/caduceus/outboundSender_test.go
+++ b/src/caduceus/outboundSender_test.go
@@ -212,6 +212,30 @@ func TestSimpleJSONWithWildcardMatchers(t *testing.T) {
 	assert.Equal(int32(4), trans.i)
 }
 
+// Simple test that covers the unsuccessful case for event wildcard matcher
+func TestSimpleJSONWithUnsuccessfulWildcardMatchers(t *testing.T) {
+
+	assert := assert.New(t)
+
+	trans := &transport{}
+
+	m := []string{".*"}
+
+	obs, err := simpleSetup(trans, time.Second, m)
+	assert.Nil(err)
+
+	req := simpleJSONRequest()
+
+	obs.QueueJSON(req, "iotfoo", "mac:112233445565", "1234")
+	obs.QueueJSON(req, "testfoo", "mac:112233445566", "1234")
+	obs.QueueJSON(req, "fooiot", "mac:112233445560", "1234")
+	obs.QueueJSON(req, "footest", "mac:112233445560", "1234")
+
+	obs.Shutdown(true)
+
+	assert.Equal(int32(0), trans.i)
+}
+
 // Simple test that covers the normal successful case with no extra matchers
 func TestSimpleWrp(t *testing.T) {
 
@@ -349,6 +373,71 @@ func TestSimpleWrpWithWildcardMatchers(t *testing.T) {
 	obs.Shutdown(true)
 
 	assert.Equal(int32(4), trans.i)
+}
+
+// Simple test that covers the unsuccessful case for event wildcard matcher
+func TestSimpleWrpWithUnsuccessfulWildcardMatchers(t *testing.T) {
+
+	assert := assert.New(t)
+
+	trans := &transport{}
+
+	m := []string{".*"}
+
+	obs, err := simpleSetup(trans, time.Second, m)
+	assert.Nil(err)
+
+	req := simpleWrpRequest()
+	req.PayloadAsWrp.TransactionUUID = "1234"
+	req.PayloadAsWrp.Source = "mac:112233445566"
+	req.PayloadAsWrp.Destination = "event:iotfoo"
+	obs.QueueWrp(req)
+
+	r2 := simpleWrpRequest()
+	r2.PayloadAsWrp.TransactionUUID = "1234"
+	r2.PayloadAsWrp.Source = "mac:112233445565"
+	r2.PayloadAsWrp.Destination = "event:testfoo"
+	obs.QueueWrp(r2)
+
+	r3 := simpleWrpRequest()
+	r3.PayloadAsWrp.TransactionUUID = "1234"
+	r3.PayloadAsWrp.Source = "mac:112233445560"
+	r3.PayloadAsWrp.Destination = "event:fooiot"
+	obs.QueueWrp(r3)
+
+	r4 := simpleWrpRequest()
+	r4.PayloadAsWrp.TransactionUUID = "1234"
+	r4.PayloadAsWrp.Source = "mac:112233445560"
+	r4.PayloadAsWrp.Destination = "event:footest"
+	obs.QueueWrp(r4)
+
+	r5 := simpleWrpRequest()
+	r5.PayloadAsWrp.TransactionUUID = "1234"
+	r5.PayloadAsWrp.Source = "mac:112233445560"
+	r5.PayloadAsWrp.Destination = "eventfoo:iot"
+	obs.QueueWrp(r5)
+
+	r6 := simpleWrpRequest()
+	r6.PayloadAsWrp.TransactionUUID = "1234"
+	r6.PayloadAsWrp.Source = "mac:112233445560"
+	r6.PayloadAsWrp.Destination = "fooevent:iot"
+	obs.QueueWrp(r6)
+
+	r7 := simpleWrpRequest()
+	r7.PayloadAsWrp.TransactionUUID = "1234"
+	r7.PayloadAsWrp.Source = "mac:112233445560"
+	r7.PayloadAsWrp.Destination = "eventfoo:test"
+	obs.QueueWrp(r7)
+
+	r8 := simpleWrpRequest()
+	r8.PayloadAsWrp.TransactionUUID = "1234"
+	r8.PayloadAsWrp.Source = "mac:112233445560"
+	r8.PayloadAsWrp.Destination = "eventfoo:test"
+	obs.QueueWrp(r8)
+
+	obs.Shutdown(true)
+
+	assert.Equal(int32(0), trans.i)
 }
 
 /*


### PR DESCRIPTION
…tch exactly what the event matcher specifies.  ie, nothing before or after.  also, wrp message destinations are checked to have a "event:" prefix and then the event is matched.

tests also were added.