### PR TITLE
Read endpoint scheme from the configuration.

### DIFF
--- a/src/caduceus/caduceus.go
+++ b/src/caduceus/caduceus.go
@@ -204,8 +204,13 @@ func caduceus(arguments []string) int {
 	router.Handle("/hook", caduceusHandler.ThenFunc(webhookRegistry.UpdateRegistry))
 	router.Handle("/hooks", caduceusHandler.ThenFunc(webhookRegistry.GetRegistry))
 
+	scheme := v.GetString("scheme")
+	if len(scheme) < 1 {
+		scheme = "https"
+	}
+
 	selfURL := &url.URL{
-		Scheme: "https",
+		Scheme: scheme,
 		Host:   v.GetString("fqdn") + v.GetString("primary.address"),
 	}
 


### PR DESCRIPTION
This change allows us to configure Caduceus to receive AWS notifications in an insecure endpoint.
By default it will use HTTPS.

Although we do not use it in production scenarios, this is useful in development scenarios where we do not use HTTPS.