### PR TITLE
Add a function that returns that it should ALWAYS retry when delivery…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Fix for webhook update for all fields
+- Fix for retry logic so all failures are retried the specified number of times
 
 ## [0.1.1] - 2018-04-06
 ### Added

--- a/src/caduceus/outboundSender.go
+++ b/src/caduceus/outboundSender.go
@@ -463,6 +463,8 @@ func (obs *CaduceusOutboundSender) worker(id int) {
 		Retries:  obs.deliveryRetries,
 		Interval: obs.deliveryInterval,
 		Counter:  simpleCounter,
+		// Always retry on failures up to the max count.
+		ShouldRetry: func(error) bool { return true },
 	}
 
 	// Only optimize the successful answers


### PR DESCRIPTION
… failed.  This will cause Caduceus to attempt delivery up to the maximum number of specified deliveries, regardless of the source of error.