### PR TITLE
Passing SOA Provider to webhookfactory

### DIFF
--- a/example-caduceus.yaml
+++ b/example-caduceus.yaml
@@ -12,6 +12,8 @@ log:
 env: test
 fqdn: 127.0.0.1
 scheme: http
+soa:
+  provider: "localhost:5079"
 
 numWorkerThreads: 10
 jobQueueSize: 10

--- a/src/caduceus/caduceus.go
+++ b/src/caduceus/caduceus.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Comcast/webpa-common/webhook"
 	"github.com/Comcast/webpa-common/webhook/aws"
 	"github.com/SermoDigital/jose/jwt"
+	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
 	"github.com/spf13/pflag"
@@ -205,7 +206,7 @@ func caduceus(arguments []string) int {
 
 	webhookFactory.Initialize(router, selfURL, v.GetString("soa.provider"), webhookHandler, logger, metricsRegistry, nil)
 
-	_, runnable := webPA.Prepare(logger, nil, metricsRegistry, router)
+	_, runnable, done := webPA.Prepare(logger, nil, metricsRegistry, router)
 
 	waitGroup, shutdown, err := concurrent.Execute(runnable)
 	if err != nil {
@@ -246,6 +247,20 @@ func caduceus(arguments []string) int {
 
 	signals := make(chan os.Signal, 10)
 	signal.Notify(signals)
+	for exit := false; !exit; {
+		select {
+		case s := <-signals:
+			if s != os.Kill && s != os.Interrupt {
+				logger.Log(level.Key(), level.InfoValue(), logging.MessageKey(), "ignoring signal", "signal", s)
+			} else {
+				logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "exiting due to signal", "signal", s)
+				exit = true
+			}
+		case <-done:
+			logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "one or more servers exited")
+			exit = true
+		}
+	}
 	s := server.SignalWait(infoLog, signals, os.Interrupt, os.Kill)
 	errorLog.Log(logging.MessageKey(), "exiting due to signal", "signal", s)
 	close(shutdown)

--- a/src/caduceus/caduceus.go
+++ b/src/caduceus/caduceus.go
@@ -203,7 +203,7 @@ func caduceus(arguments []string) int {
 		Host:   v.GetString("fqdn") + v.GetString("primary.address"),
 	}
 
-	webhookFactory.Initialize(router, selfURL, webhookHandler, logger, metricsRegistry, nil)
+	webhookFactory.Initialize(router, selfURL, v.GetString("soa.provider"), webhookHandler, logger, metricsRegistry, nil)
 
 	_, runnable := webPA.Prepare(logger, nil, metricsRegistry, router)
 

--- a/src/glide.lock
+++ b/src/glide.lock
@@ -1,5 +1,5 @@
-hash: 2c2301e03e3945fe00317a49a82372404357d670eae0266c64fedc6f9fcb3196
-updated: 2018-08-20T15:37:14.143476-07:00
+hash: c3395af2983046aca16744ccb81883d00e953538ed99dfccf19f2cef6e7679f5
+updated: 2018-10-09T07:44:31.040509-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 7be45195c3af1b54a609812f90c05a7e492e2491
@@ -38,7 +38,7 @@ imports:
   subpackages:
   - linux
 - name: github.com/Comcast/webpa-common
-  version: fe5c1484b2da90c16669df9a4e92d0517c29fff5
+  version: 06a48c25796c0c72ba091ebd8b9e7eeca94c1d96
   subpackages:
   - concurrent
   - convey
@@ -46,27 +46,21 @@ imports:
   - device
   - health
   - logging
-  - middleware
-  - middleware/fanout
   - resource
   - secure
   - secure/handler
   - secure/key
   - server
-  - tracing
-  - tracing/tracinghttp
-  - transport/transporthttp
   - types
   - webhook
   - webhook/aws
   - wrp
-  - wrp/wrpendpoint
   - wrp/wrphttp
   - xhttp
   - xlistener
   - xmetrics
 - name: github.com/davecgh/go-spew
-  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/fsnotify/fsnotify
@@ -98,7 +92,7 @@ imports:
 - name: github.com/go-stack/stack
   version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
 - name: github.com/golang/protobuf
-  version: 9eb2c01ac278a5d89ce4b2be68fe4500955d8179
+  version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
   - proto
 - name: github.com/gorilla/context
@@ -119,7 +113,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/influxdata/influxdb
-  version: 48797873ee24fc1dcb5a63f23474d3210f6d68c5
+  version: d977c0ac2494a59d72f41dc277771a3d297b8e98
   subpackages:
   - client/v2
   - models
@@ -138,12 +132,14 @@ imports:
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
+- name: github.com/miekg/dns
+  version: ba6747e8a94115e9dc7738afb87850687611df1b
 - name: github.com/mitchellh/mapstructure
-  version: bb74f1db0675b241733089d5a1faa5dd8b0ef57b
+  version: f15292f7a699fcc1a38a80977f80a046874ba8ac
 - name: github.com/pelletier/go-toml
-  version: c01d1270ff3e442a8a57cddc1c92dc1138598194
+  version: 603baefff989777996bf283da430d693e78eba3a
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
@@ -152,7 +148,7 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+  version: 5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f
   subpackages:
   - go
 - name: github.com/prometheus/common
@@ -188,7 +184,7 @@ imports:
 - name: github.com/spf13/viper
   version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - name: github.com/stretchr/objx
-  version: 9e1dfc121bca96d392da5d00591953bdb54ab306
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
@@ -202,12 +198,25 @@ imports:
   - codec
 - name: github.com/VividCortex/gohistogram
   version: 51564d9861991fb0ad0f531c99ef602d0f9866e6
+- name: golang.org/x/crypto
+  version: e3636079e1a4c1f337f212cc5cd2aca108f6c900
+  subpackages:
+  - ed25519
+  - ed25519/internal/edwards25519
+- name: golang.org/x/net
+  version: f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd
+  subpackages:
+  - bpf
+  - internal/iana
+  - internal/socket
+  - ipv4
+  - ipv6
 - name: golang.org/x/sys
-  version: 7138fd3d9dc8335c567ca206f4333fb75eb05d56
+  version: ac767d655b305d4e9612f5f6e33120b9176c4ad4
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 5cec4b58c438bd98288aeb248bab2c1840713d21
+  version: f21a4dfb5e38f5895301dc265a8def02365cc3d0
   subpackages:
   - transform
   - unicode/norm

--- a/src/glide.yaml
+++ b/src/glide.yaml
@@ -1,7 +1,7 @@
 package: .
 import:
 - package: github.com/Comcast/webpa-common
-  version: fe5c1484b2da90c16669df9a4e92d0517c29fff5
+  version: 06a48c25796c0c72ba091ebd8b9e7eeca94c1d96
 - package: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - package: github.com/gorilla/websocket


### PR DESCRIPTION
 - New configuration variable "soa.provider"
 - SOA Provider passed to Initialize function so that it can be
   used by the webhookfactory in DnsReady() function

requires webpa-common changes from this pull request:
https://github.com/Comcast/webpa-common/pull/334

issue:
https://github.com/Comcast/webpa-common/issues/333