### PR TITLE
caducues: add NewSenderWrapperFactory, NewSenderWrapper, rename sender to worker.

### DIFF
--- a/src/caduceus/outboundSender.go
+++ b/src/caduceus/outboundSender.go
@@ -447,7 +447,7 @@ func (obs *CaduceusOutboundSender) dispatcher() {
 			continue
 		}
 		obs.workers.Acquire()
-		go obs.send(secret, accept, msg)
+		go obs.worker(secret, accept, msg)
 	}
 
 	// Grab all the workers to make sure they are done.
@@ -456,9 +456,9 @@ func (obs *CaduceusOutboundSender) dispatcher() {
 	}
 }
 
-// send is the routine that actually takes the queued messages and delivers
+// worker is the routine that actually takes the queued messages and delivers
 // them to the listeners outside webpa
-func (obs *CaduceusOutboundSender) send(secret, acceptType string, msg *wrp.Message) {
+func (obs *CaduceusOutboundSender) worker(secret, acceptType string, msg *wrp.Message) {
 	defer obs.workers.Release()
 
 	payload := msg.Payload

--- a/src/caduceus/senderWrapper_test.go
+++ b/src/caduceus/senderWrapper_test.go
@@ -18,15 +18,16 @@ package main
 
 import (
 	"bytes"
-	"github.com/Comcast/webpa-common/logging"
-	"github.com/Comcast/webpa-common/webhook"
-	"github.com/Comcast/webpa-common/wrp"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/Comcast/webpa-common/logging"
+	"github.com/Comcast/webpa-common/webhook"
+	"github.com/Comcast/webpa-common/wrp"
+	"github.com/stretchr/testify/assert"
 )
 
 type result struct {
@@ -117,7 +118,7 @@ func getFakeFactory() *SenderWrapperFactory {
 
 func TestInvalidLinger(t *testing.T) {
 	swf := getFakeFactory()
-	sw, err := swf.New()
+	sw, err := swf.NewSenderWrapper()
 
 	assert := assert.New(t)
 	assert.Nil(sw)
@@ -155,7 +156,7 @@ func TestSwSimple(t *testing.T) {
 	swf.Sender = trans.RoundTrip
 
 	swf.Linger = 1 * time.Second
-	sw, err := swf.New()
+	sw, err := swf.NewSenderWrapper()
 
 	assert.Nil(err)
 	assert.NotNil(sw)


### PR DESCRIPTION
- adds `NewSenderWrapperFactory` reduces main footprint
- adds `NewSenderWrapper` reduces ambiguity
- renames `sender` to `worker` to keep consistent with the function's comments