### PR TITLE
caduceus: migrate to wrp-go from webpa-common/wrp

### DIFF
--- a/src/caduceus/caduceus_type.go
+++ b/src/caduceus/caduceus_type.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Comcast/webpa-common/logging"
 	"github.com/Comcast/webpa-common/secure"
 	"github.com/Comcast/webpa-common/secure/key"
-	"github.com/Comcast/webpa-common/wrp"
+	"github.com/Comcast/wrp-go/wrp"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics"
 	"time"

--- a/src/caduceus/caduceus_type_test.go
+++ b/src/caduceus/caduceus_type_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/Comcast/webpa-common/logging"
-	"github.com/Comcast/webpa-common/wrp"
+	"github.com/Comcast/wrp-go/wrp"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/src/caduceus/http.go
+++ b/src/caduceus/http.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 
 	"github.com/Comcast/webpa-common/logging"
-	"github.com/Comcast/webpa-common/wrp"
+	"github.com/Comcast/wrp-go/wrp"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics"
 	"github.com/satori/go.uuid"

--- a/src/caduceus/http_test.go
+++ b/src/caduceus/http_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/Comcast/webpa-common/logging"
-	"github.com/Comcast/webpa-common/wrp"
+	"github.com/Comcast/wrp-go/wrp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/src/caduceus/mocks_test.go
+++ b/src/caduceus/mocks_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Comcast/webpa-common/health"
 	"github.com/Comcast/webpa-common/webhook"
-	"github.com/Comcast/webpa-common/wrp"
+	"github.com/Comcast/wrp-go/wrp"
 	"github.com/go-kit/kit/metrics"
 	"github.com/stretchr/testify/mock"
 )

--- a/src/caduceus/outboundSender.go
+++ b/src/caduceus/outboundSender.go
@@ -38,9 +38,9 @@ import (
 	"github.com/Comcast/webpa-common/logging"
 	"github.com/Comcast/webpa-common/semaphore"
 	"github.com/Comcast/webpa-common/webhook"
-	"github.com/Comcast/webpa-common/wrp"
-	"github.com/Comcast/webpa-common/wrp/wrphttp"
 	"github.com/Comcast/webpa-common/xhttp"
+	"github.com/Comcast/wrp-go/wrp"
+	"github.com/Comcast/wrp-go/wrp/wrphttp"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics"
 )

--- a/src/caduceus/outboundSender_test.go
+++ b/src/caduceus/outboundSender_test.go
@@ -19,8 +19,9 @@ package main
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/Comcast/webpa-common/webhook"
-	"github.com/Comcast/webpa-common/wrp"
+	"github.com/Comcast/wrp-go/wrp"
 	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	//"github.com/stretchr/testify/mock"

--- a/src/caduceus/senderWrapper.go
+++ b/src/caduceus/senderWrapper.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/Comcast/webpa-common/webhook"
-	"github.com/Comcast/webpa-common/wrp"
+	"github.com/Comcast/wrp-go/wrp"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics"
 )

--- a/src/caduceus/senderWrapper_test.go
+++ b/src/caduceus/senderWrapper_test.go
@@ -18,15 +18,16 @@ package main
 
 import (
 	"bytes"
-	"github.com/Comcast/webpa-common/logging"
-	"github.com/Comcast/webpa-common/webhook"
-	"github.com/Comcast/webpa-common/wrp"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/Comcast/webpa-common/logging"
+	"github.com/Comcast/webpa-common/webhook"
+	"github.com/Comcast/wrp-go/wrp"
+	"github.com/stretchr/testify/assert"
 )
 
 type result struct {

--- a/src/glide.lock
+++ b/src/glide.lock
@@ -1,8 +1,8 @@
-hash: 8e0b5dc0f4fcee573e27644aa4b665502fecb68c941dad21430d3f491ee8519d
-updated: 2019-02-21T10:14:46.1291513-08:00
+hash: 0ed53e0bf11c5bbec33701d2c5a998893c5d29d871eb2242f23f9afe53dc9844
+updated: 2019-03-13T22:56:43.380258-06:00
 imports:
 - name: github.com/armon/go-metrics
-  version: 783273d703149aaeb9897cf58613d5af48861c25
+  version: f0300d1749da6fa982027e449ec0c7a145510c3c
 - name: github.com/aws/aws-sdk-go
   version: 7be45195c3af1b54a609812f90c05a7e492e2491
   subpackages:
@@ -44,8 +44,6 @@ imports:
 - name: github.com/Comcast/webpa-common
   version: ee36b7e7561c779aa65a66fbef35b46720486987
   subpackages:
-  - capacitor
-  - clock
   - concurrent
   - convey
   - convey/conveyhttp
@@ -61,27 +59,31 @@ imports:
   - server
   - service
   - service/consul
-  - service/monitor
   - service/servicecfg
   - service/zk
   - types
   - webhook
   - webhook/aws
   - wrp
-  - wrp/wrphttp
   - wrp/wrpmeta
   - xhttp
+  - xhttp/gate
   - xlistener
   - xmetrics
   - xviper
+- name: github.com/Comcast/wrp-go
+  version: b753eef3b9938f9c944accbe92c7723ce93a3d91
+  subpackages:
+  - wrp
+  - wrp/wrphttp
 - name: github.com/davecgh/go-spew
-  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
+  version: d8f796af33cc11cb798c1aaeb27a4ebc5099927d
   subpackages:
   - spew
 - name: github.com/fsnotify/fsnotify
-  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
+  version: 1485a34d5d5723fea214f5710708e19a831720e4
 - name: github.com/go-ini/ini
-  version: bda519ae5f4cbc60d391ff8610711627a08b86ae
+  version: ece0e89bb05aec0d6768f7bc1e77f11f03da0d11
 - name: github.com/go-kit/kit
   version: 12210fb6ace19e0496167bb3e667dcd91fa9f69b
   subpackages:
@@ -109,11 +111,11 @@ imports:
 - name: github.com/go-logfmt/logfmt
   version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/golang/protobuf
-  version: 9eb2c01ac278a5d89ce4b2be68fe4500955d8179
+  version: 925541529c1fa6821df4e44ce2723319eb2be768
   subpackages:
   - proto
 - name: github.com/gorilla/context
-  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+  version: 51ce91d2eaddeca0ef29a71d766bb3634dadf729
 - name: github.com/gorilla/mux
   version: 53c1911da2b537f792e7cafcb446b05ffe33b996
 - name: github.com/gorilla/websocket
@@ -123,17 +125,17 @@ imports:
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
-  version: d5fe4b57a186c716b0e00b8c301cbd9b4182694d
+  version: e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18
 - name: github.com/hashicorp/go-immutable-radix
-  version: 7f3cd4390caab3250a57f30efdb2a65dd7649ecf
+  version: 27df80928bb34bb1b0d6d0e01b9e679902e7a6b5
 - name: github.com/hashicorp/go-rootcerts
-  version: 6bb64b370b90e7ef1fa532be9e591a81c3493e00
+  version: 63503fb4e1eca22f9ae0f90b49c5d5538a0e87eb
 - name: github.com/hashicorp/golang-lru
-  version: 0fb14efe8c47ae851c0034ed7a448854d3d34cf3
+  version: 7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c
   subpackages:
   - simplelru
 - name: github.com/hashicorp/hcl
-  version: ef8a98b0bbce4a65b5aa4c368430a80ddc533168
+  version: 65a6292f0157eff210d03ed1bf6c59b190b8b906
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -145,7 +147,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/hashicorp/serf
-  version: 80ab48778deee28e4ea2dc4ef1ebb2c5f4063996
+  version: b89a09ebd4b1b570e0076d5097272e67c10ac4f6
   subpackages:
   - coordinate
 - name: github.com/influxdata/influxdb
@@ -163,21 +165,21 @@ imports:
 - name: github.com/kr/logfmt
   version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/magiconair/properties
-  version: c2353362d570a7bfa228149c62842019201cfb71
+  version: 7757cc9fdb852f7579b24170bcacda2c7471bb6a
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  version: c182affec369e30f25d3eb8cd8a478dee585ae7d
   subpackages:
   - pbutil
 - name: github.com/miekg/dns
   version: ba6747e8a94115e9dc7738afb87850687611df1b
 - name: github.com/mitchellh/go-homedir
-  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+  version: af06845cf3004701891bf4fdb884bfe4920b3727
 - name: github.com/mitchellh/mapstructure
-  version: bb74f1db0675b241733089d5a1faa5dd8b0ef57b
+  version: 3536a929edddb9a5b34bd6861dc4a9647cb459fe
 - name: github.com/pelletier/go-toml
-  version: c01d1270ff3e442a8a57cddc1c92dc1138598194
+  version: 690ec00a4b7e125266cf1c4725ae24af22564f8f
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: 5d4384ee4fb2527b0a1256a821ebfc92f91efefc
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
@@ -191,7 +193,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 7600349dcfe1abd18d72d3a1770870d9800a7801
+  version: 8b748030788ea01a6ceb5068504cfa01d1b335b1
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -200,6 +202,7 @@ imports:
   version: 54d17b57dd7d4a3aa092476596b3f8a933bde349
   subpackages:
   - internal/util
+  - iostats
   - nfs
   - xfs
 - name: github.com/samuel/go-zookeeper
@@ -217,19 +220,19 @@ imports:
 - name: github.com/spaolacci/murmur3
   version: 0d12bf811670bf6a1a63828dfbd003eded177fce
 - name: github.com/spf13/afero
-  version: 787d034dfe70e44075ccc060d346146ef53270ad
+  version: f4711e4db9e9a1d3887343acb72b2bbfc2f686f5
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: 8965335b8c7107321228e3e3702cab9832751bac
+  version: 8c9545af88b134710ab1cd196795e7f2388358d7
 - name: github.com/spf13/jwalterweatherman
-  version: 7c0cea34c8ece3fbeb2b27ab9b59511d360fb394
+  version: 94f6ae3ed3bceceafa716478c5fbf8d29ca601a1
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: github.com/spf13/viper
   version: 6d33b5a963d922d182c91e8a1c88d81fd150cfd4
 - name: github.com/stretchr/objx
-  version: 9e1dfc121bca96d392da5d00591953bdb54ab306
+  version: c61a9dfcced1815e7d40e214d00d1a8669a9f58c
 - name: github.com/stretchr/testify
   version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
@@ -244,12 +247,12 @@ imports:
 - name: github.com/VividCortex/gohistogram
   version: 51564d9861991fb0ad0f531c99ef602d0f9866e6
 - name: golang.org/x/crypto
-  version: 74369b46fc6756741c016591724fd1cb8e26845f
+  version: a1f597ede03a7bef967a422b5b3a5bd08805a01e
   subpackages:
   - ed25519
   - ed25519/internal/edwards25519
 - name: golang.org/x/net
-  version: f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd
+  version: 9f648a60d9775ef5c977e7669d1673a7a67bef33
   subpackages:
   - bpf
   - internal/iana
@@ -257,16 +260,16 @@ imports:
   - ipv4
   - ipv6
 - name: golang.org/x/sys
-  version: 7138fd3d9dc8335c567ca206f4333fb75eb05d56
+  version: fead79001313d15903fb4605b4a1b781532cd93e
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 5cec4b58c438bd98288aeb248bab2c1840713d21
+  version: 5d731a35f4867878fc89f7744f7b6debb3beded6
   subpackages:
   - transform
   - unicode/norm
 - name: gopkg.in/natefinch/lumberjack.v2
   version: a96e63847dc3c67d17befa69c303767e2f84e54f
 - name: gopkg.in/yaml.v2
-  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+  version: 51d6538a90f86fe93ac480b35f37b2be17fef232
 testImports: []

--- a/src/glide.yaml
+++ b/src/glide.yaml
@@ -2,5 +2,12 @@ package: .
 import:
 - package: github.com/Comcast/webpa-common
   version: ee36b7e7561c779aa65a66fbef35b46720486987
+  ignore:
+    github.com/Comcast/webpa-common/wrp
 - package: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
+- package: github.com/influxdata/influxdb
+  version: 48797873ee24fc1dcb5a63f23474d3210f6d68c5
+- package: github.com/prometheus/client_model
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+


### PR DESCRIPTION
Changes webpa-common/wrp dependencies to wrp-go/wrp and also updates glide.